### PR TITLE
feat: change readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Calculate word counts in a text file!!
 ## Installation
 
 ```bash
-$ pip install pycounts_thomassiu
+$ pip install pycounts_thomassiu s
 ```
 
 ## Usage


### PR DESCRIPTION
perf(pencil): remove graphiteWidth option

BREAKING CHANGE: The graphiteWidth option has been removed.
The default graphite width of 10mm is always used for performance reasons.